### PR TITLE
Return empty hash when no keys are passed to the Storage#count method

### DIFF
--- a/lib/time_window_drop_collector/storage.rb
+++ b/lib/time_window_drop_collector/storage.rb
@@ -14,6 +14,8 @@ class TimeWindowDropCollector::Storage
   end
 
   def count( keys )
+    return {} if keys.empty?
+
     window_keys = window_keys_multi( keys )
     keys_values = wrapper.get( window_keys )
 

--- a/test/memcache_wrapper_test.rb
+++ b/test/memcache_wrapper_test.rb
@@ -2,20 +2,14 @@ require_relative "test_helper"
 
 class MemcacheWrapperTest < Test::Unit::TestCase
   def test_initialize
-    Dalli::Client.expects( :new ).with( "arg1" ).returns( "client" )
+    Dalli::Client.expects( :new ).with( ["arg1"] ).returns( "client" )
     wrapper = TimeWindowDropCollector::Wrappers::Memcache.new( ["arg1"] )
     assert_equal( "client", wrapper.client )
   end
 
   def test_incr
     wrapper = TimeWindowDropCollector::Wrappers::Memcache.new( ["arg1"] )
-    wrapper.client.expects( :incr ).with( "key", 5, "expire_time", 1 )
-    wrapper.incr( "key", "expire_time", 5 )
-  end
-
-  def test_values_for
-    wrapper = TimeWindowDropCollector::Wrappers::Memcache.new( ["arg1"] )
-    wrapper.client.expects( :get_multi ).with( "keys" ).returns( {:a => 1, :b => 2} )
-    assert_equal( [1, 2], wrapper.values_for( "keys" ))
+    wrapper.client.expects( :incr ).with( "key", 5, "expire_time", 1)
+    wrapper.incr( ["key"], "expire_time", 5 )
   end
 end

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -7,13 +7,13 @@ class StorageTest < Test::Unit::TestCase
   end
 
   def test_timestamp_key_when_time_is_present
-    timestamp = Time.new( 2001, 2, 3, 4, 5 )
-    assert_equal( "drop_window_key_981169500000", @storage.timestamp_key( "key", timestamp ) )
+    timestamp = Time.new(2001, 2, 3, 4, 5, 0, "+01:00")
+    assert_equal("drop_window_key_981169500000", @storage.timestamp_key("key", timestamp))
   end
 
   def test_timestamp_key_when_time_is_not_present
-    @storage.stubs( :timestamp ).returns( Time.new( 2012, 4, 3, 2, 1 ))
-    assert_equal( "drop_window_key_1333411260000", @storage.timestamp_key( "key" ))
+    @storage.stubs(:timestamp).returns(Time.new(2012, 4, 3, 2, 1, 0, "+02:00"))
+    assert_equal("drop_window_key_1333411260000", @storage.timestamp_key("key"))
   end
 
   def test_window_keys_should_return_10_keys_for_the_last_10_minutes
@@ -30,8 +30,8 @@ class StorageTest < Test::Unit::TestCase
       "drop_window_key_1325560260000"
     ]
 
-    Delorean.time_travel_to( '2012-01-03 04:20' ) do
-      assert_equal( keys, @storage.window_keys( "key" ))
+    Delorean.time_travel_to('2012-01-03 04:20 +01:00') do
+      assert_equal(keys, @storage.window_keys("key"))
     end
   end
 
@@ -126,19 +126,19 @@ class StorageTest < Test::Unit::TestCase
   end
 
   def test_slice_start_timestamp
-    storage = TimeWindowDropCollector::Storage.new( nil, 100, 10 )
-    time    = Time.new( 2001, 2, 3, 4, 5 )
+    storage = TimeWindowDropCollector::Storage.new(nil, 100, 10)
+    time    = Time.new(2001, 2, 3, 4, 5, 0, '+01:00')
 
-    assert_equal( 981169500000, storage.slice_start_timestamp( time ) )
-    assert_equal( 981169500000, storage.slice_start_timestamp( time + 1 ) )
-    assert_equal( 981169500000, storage.slice_start_timestamp( time + 9 ) )
-    assert_equal( 981169520000, storage.slice_start_timestamp( time + 25 ) )
-    assert_equal( 981169600000, storage.slice_start_timestamp( time + 100 ) )
+    assert_equal(981169500000, storage.slice_start_timestamp(time))
+    assert_equal(981169500000, storage.slice_start_timestamp(time + 1))
+    assert_equal(981169500000, storage.slice_start_timestamp(time + 9))
+    assert_equal(981169520000, storage.slice_start_timestamp(time + 25))
+    assert_equal(981169600000, storage.slice_start_timestamp(time + 100))
   end
 
   def test_slice_start_timestamp_with_slice_sizes_no_integer
     storage = TimeWindowDropCollector::Storage.new( nil, 100, 12 )
-    time    = Time.new( 2001, 2, 3, 4, 5 )
+    time    = Time.new( 2001, 2, 3, 4, 5, 0,'+01:00')
 
     assert_equal( 981169493317, storage.slice_start_timestamp( time ) )
     assert_equal( 981169493317, storage.slice_start_timestamp( time + 1 ) )
@@ -148,14 +148,14 @@ class StorageTest < Test::Unit::TestCase
   end
 
   def test_slice_start_timestamp_with_slice_size_less_than_a_second
-    storage = TimeWindowDropCollector::Storage.new( nil, 100, 101 )
-    time    = Time.new( 2001, 2, 3, 4, 5 )
+    storage = TimeWindowDropCollector::Storage.new(nil, 100, 101)
+    time    = Time.new( 2001, 2, 3, 4, 5, 0, '+01:00')
 
-    assert_equal( 981169499970, storage.slice_start_timestamp( time ) )
-    assert_equal( 981169500960, storage.slice_start_timestamp( time + 1 ) )
-    assert_equal( 981169508880, storage.slice_start_timestamp( time + 9 ) )
-    assert_equal( 981169524720, storage.slice_start_timestamp( time + 25 ) )
-    assert_equal( 981169599960, storage.slice_start_timestamp( time + 100 ) )
+    assert_equal(981169499970, storage.slice_start_timestamp(time))
+    assert_equal(981169500960, storage.slice_start_timestamp(time + 1))
+    assert_equal(981169508880, storage.slice_start_timestamp(time + 9))
+    assert_equal(981169524720, storage.slice_start_timestamp(time + 25))
+    assert_equal(981169599960, storage.slice_start_timestamp(time + 100))
   end
 
   def test_window_size_consistency

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -57,6 +57,10 @@ class StorageTest < Test::Unit::TestCase
     assert_equal( "grouping_keys_counts", @storage.count( "keys" ))
   end
 
+  def test_count_with_no_keys
+    assert_equal({}, @storage.count([]))
+  end
+
   def test_grouping_count
     key_values = {
       "drop_window_key1_201201031416" => 1,


### PR DESCRIPTION
Looks convenient to avoid touching the storage if no keys are passed. For some cases, e.g. Redis wrapper, we even get an error since the `mget` method doesn't accept an empty keys list. Suggestions are welcome :)
